### PR TITLE
Add variable read length support to prepSample.sh

### DIFF
--- a/prepSamples.sh
+++ b/prepSamples.sh
@@ -30,7 +30,7 @@ do
 			chr$ARG_TASKID \
 			-f 16 -F 4 -q 1 | \
 			$SCRIPT_PYTHON $SCRIPT_RETRO | \
-					awk '{print $4+50}' \
+					awk '{print ($4 + length($10) - 1)}' \
 					    > $OUTFILE.$ARG_TASKID.start.rev
 		done
 done


### PR DESCRIPTION
Hello, here is a little modification to be able to run the prepSample.sh script on sequences with variable read length, typically Ion Torrent data.
